### PR TITLE
Remove the wave header when decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The following benchmarks were made on a 4.600GHz 12th Gen Intel i7-12700H CPU wi
 ## Decoding
 | File size | Audio file size | Audio length | Speed | Link |
 |-----------|-----------------|------|-------| ---- |
-| 2687.94MB | 2687.94MB | 01:28:13 | 12.76s | [Soundcloud-link](https://soundcloud.com/awiteb/pop-os-2204-amd64-intel-23iso) |
-| 35.3MB | 35.3MB | 00:01::27 | 206.04ms | [Soundcloud-link](https://soundcloud.com/awiteb/rust-1671zip) |
+| 2687.94MB | 2687.94MB | 01:28:13 | 5.14s | [Soundcloud-link](https://soundcloud.com/awiteb/pop-os-2204-amd64-intel-23iso) |
+| 35.3MB | 35.3MB | 00:01::27 | 117.58ms | [Soundcloud-link](https://soundcloud.com/awiteb/rust-1671zip) |
 
 ## Disclaimer
 This tool was designed for educational purposes as it explains how to save data in an audio file. It is not recommended to exploit this thing to use cloud audio storage services to store your data, as your account may be banned.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,8 @@ pub enum Error {
     Io(std::io::Error),
     /// Larg file size error (maxnimum file size is 4 GB)
     LargeFileSize,
+    /// Invalid wav file error
+    InvalidWavFile(String),
 }
 
 impl From<hound::Error> for Error {
@@ -32,6 +34,7 @@ impl fmt::Display for Error {
             Error::Hound(err) => write!(f, "Hound error: {}", err),
             Error::Io(err) => write!(f, "IO error: {}", err),
             Error::LargeFileSize => write!(f, "File size is too large, maximum file size is 4 GB"),
+            Error::InvalidWavFile(msg) => write!(f, "Invalid wav file, {}", msg),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub fn encode(file: fs::File, wav_output: impl AsRef<path::Path>) -> Result<()> 
 pub fn decode(file: impl AsRef<path::Path>, output: impl AsRef<path::Path>) -> Result<()> {
     let output_file = fs::File::open(&file)?;
     utils::check_file_size(&output_file)?;
+    utils::check_wav_file_size(&output_file)?;
     let mut reader = BufReader::new(output_file);
     let mut writer = BufWriter::new(fs::File::create(output)?);
     // Skip the header, to get to the data (the header is 44 bytes long)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,3 +7,16 @@ pub(crate) fn check_file_size(file: &fs::File) -> Result<()> {
         .then(|| Err(Error::LargeFileSize))
         .unwrap_or(Ok(()))
 }
+
+/// Check if the wav file size is valid, the minimum size is 44 bytes. (the maximum will checked with `check_file_size`)
+/// ### Note
+/// The 44 bytes are the header of the wav file.
+pub(crate) fn check_wav_file_size(file: &fs::File) -> Result<()> {
+    (file.metadata()?.len() < 44)
+        .then(|| {
+            Err(Error::InvalidWavFile(
+                "the minimum size is 44 bytes".to_owned(),
+            ))
+        })
+        .unwrap_or(Ok(()))
+}


### PR DESCRIPTION
Closes #3 
Remove the header when decoding the file, instead of converting the wave file to samples